### PR TITLE
Remove react virtualized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@types/node": "^16.18.66",
         "@types/react": "^18.2.40",
         "@types/react-dom": "^18.2.17",
-        "@uidotdev/usehooks": "^2.4.1",
         "antd": "^5.11.5",
         "axios": "^1.6.2",
         "dayjs": "^1.11.10",
@@ -35,8 +34,6 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.1",
         "react-scripts": "5.0.1",
-        "react-virtualized": "^9.22.5",
-        "react-window": "^1.8.10",
         "sort-by": "^1.2.0",
         "styled-components": "^6.1.1",
         "typescript": "^4.9.5",
@@ -4837,18 +4834,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@uidotdev/usehooks": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
-      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -6284,14 +6269,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7262,15 +7239,6 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -12675,11 +12643,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -18531,11 +18494,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -18644,39 +18602,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-virtualized": {
-      "version": "9.22.5",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.5.tgz",
-      "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-window": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
-      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/node": "^16.18.66",
     "@types/react": "^18.2.40",
     "@types/react-dom": "^18.2.17",
-    "@uidotdev/usehooks": "^2.4.1",
     "antd": "^5.11.5",
     "axios": "^1.6.2",
     "dayjs": "^1.11.10",
@@ -30,8 +29,6 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.1",
     "react-scripts": "5.0.1",
-    "react-virtualized": "^9.22.5",
-    "react-window": "^1.8.10",
     "sort-by": "^1.2.0",
     "styled-components": "^6.1.1",
     "typescript": "^4.9.5",
@@ -63,7 +60,17 @@
       "react-app/jest",
       "plugin:react-hooks/recommended",
       "prettier"
-    ]
+    ],
+    "rules": {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ]
+    }
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",

--- a/src/components/channel/ChannelChatBox.tsx
+++ b/src/components/channel/ChannelChatBox.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   Row,
   Space,
+  Spin,
   Tooltip,
   Typography,
 } from 'antd';
@@ -31,11 +32,12 @@ import { ReactionOpType } from '../../types/reaction';
 import { Channel as WFChannel } from '@wingflo/js-sdk';
 
 const { Title } = Typography;
-const Box = styled(Flex)`
+const Box = styled(Col)`
+  display: flex;
+  flex-direction: column;
   height: calc(100vh - 48px);
   background: #fff;
-  flex-grow: 1;
-  min-width: 500px;
+  width: 660px;
 `;
 
 const ChannelChatHeader = styled.div`
@@ -58,7 +60,7 @@ const ChatInputBoxWrapper = styled.div`
   flex: 0 0 auto;
   display: flex;
   justify-content: center;
-  margin-bottom: 16px;
+  margin: 0 16px 16px;
 `;
 
 const ChatMessageBox = styled.div`
@@ -72,6 +74,7 @@ const ThreadDrawerCol = styled(Col)`
   display: flex;
   flex-direction: column;
   border-left: 1px solid #e0e0e0;
+  width: 280px;
 `;
 
 const ThreadDrawerHeader = styled(Flex)`
@@ -168,7 +171,8 @@ const ChannelChatBox = ({
   };
 
   return (
-    <Box vertical style={{}}>
+    <Box flex="1'0 auto">
+      '{' '}
       <ChannelChatHeader>
         <Space>
           <img
@@ -192,15 +196,16 @@ const ChannelChatBox = ({
         </Space>
       </ChannelChatHeader>
       {/* ChannelChatBody */}
-      <Row style={{ flexGrow: 1 }}>
+      <Row style={{ flexGrow: 1 }} wrap={false}>
         {/* ChannelChat main chat column (excluding threadbox column) */}
         <Col
-          flex="auto"
+          flex="1 0 auto"
           style={{
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',
             height: 'calc( 100vh - 48px - 64px )',
+            width: 380,
           }}
         >
           {/*  chat box */}
@@ -248,7 +253,7 @@ const ChannelChatBox = ({
 
         {/* Replies */}
         {selectedMessage && (
-          <ThreadDrawerCol flex="280px">
+          <ThreadDrawerCol flex="0 0 auto">
             <ThreadDrawerHeader justify="space-between" align="center">
               <span style={{ fontSize: 14, fontWeight: 600 }}>Thread</span>
               <Button
@@ -258,43 +263,48 @@ const ChannelChatBox = ({
               />
             </ThreadDrawerHeader>
             {/*  selected msg*/}
-            <MessageLine
-              message={selectedMessage}
-              displayMode="thread-full"
-              onReaction={handleReaction}
-              currentUser={commonStore.moderator}
-            />
-            <Divider plain orientation="left">
-              {selectedMessage.thread_info?.reply_count ?? 0} replies
-            </Divider>
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                flexGrow: 1,
-                height: 1,
-              }}
-              ref={replyMessageBoxRef}
-            >
-              <ChannelChatRepliesList
-                replies={replies}
-                onReaction={handleReaction}
-                currentUser={commonStore.moderator}
-                loading={repliesLoading}
-              />
-              <ChatInputBox
-                chatBoxBorderColor={chatBoxBorderColor}
-                onSendMessage={(message) =>
-                  onSendMessage(message, selectedMessage)
-                }
-                onUpload={onReplyUpload}
-                uploadFiles={replyUploadFiles}
-                onUploadRemove={onReplyUploadRemove}
-                style={{
-                  margin: '10px 16px 16px',
-                }}
-              />
-            </div>
+            {repliesLoading ? (
+              <Spin spinning={true} style={{ margin: '50px 0' }} />
+            ) : (
+              <>
+                <MessageLine
+                  message={selectedMessage}
+                  displayMode="thread-full"
+                  onReaction={handleReaction}
+                  currentUser={commonStore.moderator}
+                />
+                <Divider plain orientation="left">
+                  {selectedMessage.thread_info?.reply_count ?? 0} replies
+                </Divider>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    flexGrow: 1,
+                    height: 1,
+                  }}
+                  ref={replyMessageBoxRef}
+                >
+                  <ChannelChatRepliesList
+                    replies={replies}
+                    onReaction={handleReaction}
+                    currentUser={commonStore.moderator}
+                  />
+                  <ChatInputBox
+                    chatBoxBorderColor={chatBoxBorderColor}
+                    onSendMessage={(message) =>
+                      onSendMessage(message, selectedMessage)
+                    }
+                    onUpload={onReplyUpload}
+                    uploadFiles={replyUploadFiles}
+                    onUploadRemove={onReplyUploadRemove}
+                    style={{
+                      margin: '10px 16px 16px',
+                    }}
+                  />
+                </div>
+              </>
+            )}
           </ThreadDrawerCol>
         )}
       </Row>

--- a/src/components/channel/ChannelChatBox.tsx
+++ b/src/components/channel/ChannelChatBox.tsx
@@ -1,4 +1,13 @@
-import { Button, Col, Divider, Flex, Row, Space, Typography } from 'antd';
+import {
+  Button,
+  Col,
+  Divider,
+  Flex,
+  Row,
+  Space,
+  Tooltip,
+  Typography,
+} from 'antd';
 import defaultChannelImg from '../../static/images/default-channel-image-1.png';
 import {
   CloseOutlined,
@@ -78,10 +87,20 @@ const ChatMessageBoxOverlay = styled.div`
   z-index: 100;
 `;
 
+const ScrollToBottomWrapper = styled.div`
+  max-width: 988px;
+  width: 100%;
+  height: 0;
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 auto;
+`;
+
 const ScrollToBottomButton = styled(Button)`
   position: absolute;
   bottom: 8px;
-  right: 70px;
+  right: 16px;
 `;
 const ChannelChatBox = ({
   chatMessageBoxRef,
@@ -197,18 +216,22 @@ const ChannelChatBox = ({
                 currentUser={commonStore.moderator}
               />
             </ChatMessageBox>
-
-            <ScrollToBottomButton
-              type="primary"
-              shape="circle"
-              icon={<DownOutlined />}
-              onClick={scrollChatMessageBoxToBottom}
-              size="large"
-              style={{
-                display: isChatMessageBoxScrollAtBottom ? 'block' : 'none',
-              }}
-            />
           </ChatMessageBoxWrapper>
+
+          <ScrollToBottomWrapper>
+            <Tooltip title="Go to bottom">
+              <ScrollToBottomButton
+                type="primary"
+                shape="circle"
+                icon={<DownOutlined />}
+                onClick={scrollChatMessageBoxToBottom}
+                size="large"
+                style={{
+                  display: isChatMessageBoxScrollAtBottom ? 'block' : 'none',
+                }}
+              />
+            </Tooltip>
+          </ScrollToBottomWrapper>
 
           {/*chat input*/}
           <ChatInputBoxWrapper className="chat-input-box-wrapper">
@@ -222,6 +245,8 @@ const ChannelChatBox = ({
             />
           </ChatInputBoxWrapper>
         </Col>
+
+        {/* Replies */}
         {selectedMessage && (
           <ThreadDrawerCol flex="280px">
             <ThreadDrawerHeader justify="space-between" align="center">

--- a/src/components/channel/ChannelChatRepliesList.tsx
+++ b/src/components/channel/ChannelChatRepliesList.tsx
@@ -1,25 +1,18 @@
 import React from 'react';
 import { MessageLine } from '../message/MessageLine';
 import { MessageType } from '../../types/message';
-import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
-import List from 'react-virtualized/dist/commonjs/List';
-import { CellMeasurer, CellMeasurerCache } from 'react-virtualized';
 import { UserListRes } from '../../types/user';
 import { ReactionOpType } from '../../types/reaction';
+import { Empty, Spin } from 'antd';
 
-const cache = new CellMeasurerCache({
-  fixedWidth: true,
-  defaultWidth: 280,
-  defaultHeight: 50,
-});
 export const ChannelChatRepliesList = ({
+  loading,
   replies,
-  repliesListRef,
   onReaction,
   currentUser,
 }: {
+  loading: boolean;
   replies: MessageType[];
-  repliesListRef: React.RefObject<List>;
   onReaction: (
     message: MessageType,
     reaction: string,
@@ -27,42 +20,25 @@ export const ChannelChatRepliesList = ({
   ) => void;
   currentUser: UserListRes | null;
 }) => {
-  console.log('replies', replies);
+  if (loading) {
+    return <Spin spinning={true} style={{ margin: '50px 0' }} />;
+  }
   return (
-    <div style={{ height: '100%', width: '100%' }}>
-      <AutoSizer disableWidth>
-        {({ height }) => (
-          <List
-            ref={repliesListRef}
-            height={height}
-            width={280}
-            rowCount={replies.length}
-            overscanRowCount={100}
-            rowHeight={cache.rowHeight}
-            deferredMeasurementCache={cache}
-            rowRenderer={({ index, key, style, parent }) => {
-              const reply = replies[index];
-              return (
-                <CellMeasurer
-                  cache={cache}
-                  parent={parent}
-                  rowIndex={index}
-                  key={key}
-                >
-                  <MessageLine
-                    key={key}
-                    style={style}
-                    message={reply}
-                    displayMode="thread-compact"
-                    onReaction={onReaction}
-                    currentUser={currentUser}
-                  />
-                </CellMeasurer>
-              );
-            }}
+    <div>
+      {replies.length === 0 && (
+        <Empty description="No replies" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      )}
+      {replies.map((reply, index) => {
+        return (
+          <MessageLine
+            key={reply.uuid}
+            message={reply}
+            displayMode="thread-compact"
+            onReaction={onReaction}
+            currentUser={currentUser}
           />
-        )}
-      </AutoSizer>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/channel/ChannelChatRepliesList.tsx
+++ b/src/components/channel/ChannelChatRepliesList.tsx
@@ -3,15 +3,13 @@ import { MessageLine } from '../message/MessageLine';
 import { MessageType } from '../../types/message';
 import { UserListRes } from '../../types/user';
 import { ReactionOpType } from '../../types/reaction';
-import { Empty, Spin } from 'antd';
+import { Empty } from 'antd';
 
 export const ChannelChatRepliesList = ({
-  loading,
   replies,
   onReaction,
   currentUser,
 }: {
-  loading: boolean;
   replies: MessageType[];
   onReaction: (
     message: MessageType,
@@ -20,9 +18,6 @@ export const ChannelChatRepliesList = ({
   ) => void;
   currentUser: UserListRes | null;
 }) => {
-  if (loading) {
-    return <Spin spinning={true} style={{ margin: '50px 0' }} />;
-  }
   return (
     <div>
       {replies.length === 0 && (

--- a/src/components/channel/ChannelInfoSideBar.tsx
+++ b/src/components/channel/ChannelInfoSideBar.tsx
@@ -1,6 +1,7 @@
 import {
   Badge,
   Button,
+  Col,
   Collapse,
   Descriptions,
   Drawer,
@@ -15,8 +16,9 @@ import styled from 'styled-components';
 
 const { Text, Title } = Typography;
 
-const ChannelInfoRightSideBar = styled(Flex)`
-  width: 320px;
+const ChannelInfoRightSideBar = styled(Col)`
+  display: flex;
+  flex-direction: column;
   border-left: 1px solid #e0e0e0;
   position: relative;
 `;
@@ -44,8 +46,8 @@ export const ChannelInfoSideBar = ({ onClose }: { onClose: () => void }) => {
   const [membersDrawerOpen, setMembersDrawerOpen] = useState(false);
 
   return (
-    <ChannelInfoRightSideBar vertical>
-      {/*  channel info */}
+    <ChannelInfoRightSideBar flex="320'x">
+      ' {/*  channel info */}
       <ChannelInfoRightSideBarHeader justify="space-between" align="center">
         <Title level={5} style={{ margin: 0, fontWeight: 700 }}>
           Channel information
@@ -109,7 +111,6 @@ export const ChannelInfoSideBar = ({ onClose }: { onClose: () => void }) => {
           defaultActiveKey={['1']}
         />
       </div>
-
       <Drawer
         title={
           <Flex justify="space-between" style={{ height: 63 }} align="center">

--- a/src/components/channel/ChannelListSideBar.tsx
+++ b/src/components/channel/ChannelListSideBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, List, Space, theme, Typography } from 'antd';
+import { Button, Col, Flex, List, Space, theme, Typography } from 'antd';
 import {
   ArrowLeftOutlined,
   SearchOutlined,
@@ -13,9 +13,7 @@ import { type ChannelListRes } from '@wingflo/js-sdk';
 
 const { Text, Title } = Typography;
 
-const Box = styled.div`
-  width: 320px;
-  min-width: 320px;
+const Box = styled(Col)`
   background-color: #fff;
   border-right: 1px solid #e0e0e0;
 `;
@@ -51,7 +49,7 @@ export const ChannelListSideBar = ({
   const { token } = theme.useToken();
 
   return (
-    <Box>
+    <Box flex="320px">
       <Flex
         align="center"
         justify="space-between"

--- a/src/components/message/MessageLine.tsx
+++ b/src/components/message/MessageLine.tsx
@@ -50,6 +50,7 @@ const InnerBox = styled.div`
 
 const LeftCol = styled.div`
   width: 45px;
+  flex: 0 0 auto;
 `;
 
 const MessageTimestamp = styled.time`
@@ -257,7 +258,7 @@ export const MessageLine = ({
                 <Avatar size={32} src={defaultUserImage} />
               )}
             </LeftCol>
-            <div>
+            <div style={{ flexGrow: 1 }}>
               {(displayMode === 'full' ||
                 displayMode === 'thread-full' ||
                 displayMode === 'thread-compact') && (

--- a/src/components/message/MessageLine.tsx
+++ b/src/components/message/MessageLine.tsx
@@ -218,7 +218,7 @@ export const MessageLine = ({
   return (
     <>
       {/* @ts-ignore */}
-      <div style={style} ref={registerChild}>
+      <div style={{ width: '100%' }} ref={registerChild}>
         {showDateLine && (
           <Divider plain orientationMargin="0">
             <div
@@ -291,10 +291,7 @@ export const MessageLine = ({
               {message.og_tag && (
                 <Card
                   style={{
-                    width:
-                      displayMode === 'full' || displayMode === 'compact'
-                        ? 300
-                        : '80%',
+                    width: isThread ? 200 : 300,
                     margin: '10px 0',
                     cursor: 'pointer',
                   }}
@@ -305,12 +302,25 @@ export const MessageLine = ({
                       <img
                         alt={message.og_tag.image_alt ?? ''}
                         src={message.og_tag.image}
-                        onLoad={onReRender}
                       />
                     )
                   }
+                  bodyStyle={{
+                    padding: 10,
+                  }}
                 >
-                  <Card.Meta title={message.og_tag.title} />
+                  <Card.Meta
+                    title={
+                      <span
+                        style={{
+                          fontSize: isThread ? 12 : 14,
+                          fontWeight: 400,
+                        }}
+                      >
+                        {message.og_tag.title}
+                      </span>
+                    }
+                  />
                 </Card>
               )}
               {/* Reactions */}

--- a/src/hooks/useScrollBottom.ts
+++ b/src/hooks/useScrollBottom.ts
@@ -1,0 +1,37 @@
+import { RefObject, useEffect, useState } from 'react';
+
+export const useScrollBottom = (
+  ref: RefObject<HTMLElement>,
+  scrollBuffer: number = 1,
+): [boolean, () => void] => {
+  const [isBottom, setIsBottom] = useState(false);
+
+  function scrollToBottom() {
+    ref.current?.scrollTo({
+      top: ref.current.scrollHeight,
+      left: 0,
+    });
+  }
+
+  useEffect(() => {
+    const element = ref.current;
+
+    function onScroll() {
+      if (!element) return;
+      setIsBottom(
+        !(
+          element.scrollTop >=
+          element.scrollHeight - element?.offsetHeight - scrollBuffer
+        ),
+      );
+    }
+
+    element?.addEventListener('scroll', onScroll);
+
+    return () => {
+      element?.removeEventListener('scroll', onScroll);
+    };
+  }, [ref]);
+
+  return [isBottom, scrollToBottom];
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,6 @@ import NotFoundPage from './pages/common/NotFoundPage';
 import ChannelChatPage from './pages/channel/ChannelChatPage';
 import ProtectedRoute from './core/auth/ProtectedRoute';
 import * as Sentry from '@sentry/react';
-import 'react-virtualized/styles.css';
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -34,7 +34,7 @@ import axios from 'axios';
 import LogoImg from '../static/images/wingflo-logo-white-wide-sm.png';
 import axiosInstance from '../axiosInstance';
 
-const { Header } = Layout;
+const { Header, Content } = Layout;
 const { Text } = Typography;
 
 const OrgProfileImgBox = styled.div`
@@ -292,7 +292,14 @@ const Root = () => {
           </Button>
         </Dropdown>
       </Header>
-      <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+      <Content
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 1,
+          // height: '100%',
+        }}
+      >
         <Outlet
           context={{
             account: commonStore.account,
@@ -301,7 +308,7 @@ const Root = () => {
             setApplications,
           }}
         />
-      </div>
+      </Content>
     </Layout>
   );
 };

--- a/src/pages/channel/ChannelChatPage.tsx
+++ b/src/pages/channel/ChannelChatPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Layout, theme } from 'antd';
+import { Row, theme } from 'antd';
 import { CommonStoreContext } from '../../index';
 import { observer } from 'mobx-react-lite';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -125,7 +125,8 @@ const ChannelChatPage = () => {
   }
 
   return (
-    <Layout
+    <Row
+      wrap={false}
       style={{
         flexGrow: 1,
         height: '100%',
@@ -173,7 +174,7 @@ const ChannelChatPage = () => {
           onClose={() => setChannelInfoRightSideBarVisible(false)}
         />
       )}
-    </Layout>
+    </Row>
   );
 };
 

--- a/src/store/ChatStore.ts
+++ b/src/store/ChatStore.ts
@@ -111,12 +111,13 @@ class ChatStore {
 
   *selectChatChannel(
     channel: WFChannelListRes,
-    messageUpdateCallback?: (messageUuid?: string) => void,
+    onMessageReceived?: (message: MessageType) => void,
   ) {
     if (this.wingFloClient == null) {
       console.warn('cannot select channel. wingflo client is not initialized.');
       return;
     }
+    this.chatMessagesState = 'pending';
     this.chatMessages = [];
     this.chatReplies = [];
     this.selectedMessage = undefined;
@@ -130,7 +131,6 @@ class ChatStore {
     yield selectedChannel.enter();
     console.debug('entered channel', selectedChannel);
     const messageCollection = selectedChannel.createMessageCollection({});
-    this.chatMessagesState = 'pending';
     let messages: MessageType[] = yield messageCollection.loadPrevious();
     this.chatMessagesState = 'done';
     console.debug('loaded messages', messages);
@@ -156,8 +156,8 @@ class ChatStore {
               // ...this.chatMessages.slice(startIndex),
               ...newMessages,
             ];
-            messageUpdateCallback?.();
           });
+          onMessageReceived?.(newMessage);
         } else if (
           this.selectedChatMessage?.uuid === newMessage.parent_message_uuid
         ) {
@@ -188,7 +188,6 @@ class ChatStore {
               this.chatMessages[index] = updatedMessage;
             });
           }
-          messageUpdateCallback?.(updatedMessage.uuid);
         } else if (
           this.selectedChatMessage?.uuid === updatedMessage.parent_message_uuid
         ) {


### PR DESCRIPTION
## ✍️ Describe your changes
### Removing React Virtualized

Previously 'react-virtualized' library was used to optimize the performance of chat message listing. If there were a few thousand messages, browser would perform poorly. Virtualized lists exist to fix such a problem.

However, I decided to remove 'react-virtualized' because of the following reasons.

1. Poor performance
I noticed that when using `CellMeasurer` component to dynamically size each row (chat msg), performance suffered.\
Further discssion on the issue can be found at https://github.com/bvaughn/react-virtualized/issues/341


https://github.com/wingflo/dashboard-front/assets/7122981/5b8c219e-f740-4ca1-8893-e0fd68cd1da9

https://github.com/wingflo/dashboard-front/assets/7122981/23630f5a-166e-4935-8015-fc2f2994e6fc


2. Too complex API
implementing a complex chat system with react-virtualized was a poor dev experience and made the development sluggish.

This however does not mean I intend to give up on the performance. I will first build out chat screen and then find other optimizations after that. It seems offloading some chat messages from the screen could be a solution. 
For example, let's say a user is looking at 100 messages at a time. We can store 100 + BUFFER amount of messages in the mobx store and pull the rest from the server as needed and offloading messages outside the visible + BUFFER range. 


### Other changes
- Removed `react-window` dependency. It was not used. Forgot to delete it from before.
- Removed `@uidotdev/usehooks` dependency. It was used to replace `AutoSizer` of `react-virtualized` to dynamically measure the width/height of chat list container. Since `react-virtualized` is removed, this is also not needed.
- Added "scroll to bottom" bottom on chat screen
- Added "no messages" icon to chat message list and reply message list.
- Fixed chat channel page layout shrinking issues.



## 🎟 ️Issue ticket number and link
closes #1 

## ✅ Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
