### PR TITLE
Fix chat message actionbox and dropdown to expected behaviour

### DIFF
--- a/src/components/channel/ChannelChatBox.tsx
+++ b/src/components/channel/ChannelChatBox.tsx
@@ -16,7 +16,7 @@ import {
   InfoCircleOutlined,
   UserAddOutlined,
 } from '@ant-design/icons';
-import React, { useContext } from 'react';
+import React, { SetStateAction, useContext } from 'react';
 import styled from 'styled-components';
 import { MessageLine } from '../message/MessageLine';
 import { MessageType } from '../../types/message';
@@ -81,15 +81,6 @@ const ThreadDrawerHeader = styled(Flex)`
   padding: 12px 10px 12px 16px;
 `;
 
-const ChatMessageBoxOverlay = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  z-index: 100;
-`;
-
 const ScrollToBottomWrapper = styled.div`
   max-width: 988px;
   width: 100%;
@@ -127,6 +118,7 @@ const ChannelChatBox = ({
   repliesLoading,
   replyUploadFiles,
   onReplyUpload,
+  setChatDropdownMaskVisible,
 }: {
   chatMessageBoxRef: React.RefObject<HTMLDivElement>;
   isChatMessageBoxScrollAtBottom: boolean;
@@ -149,6 +141,7 @@ const ChannelChatBox = ({
   repliesLoading: boolean;
   replyUploadFiles: CustomUploadFile[];
   onReplyUpload: (file: CustomUploadFile) => void;
+  setChatDropdownMaskVisible: React.Dispatch<SetStateAction<boolean>>;
 }) => {
   const chatStore = useContext(ChatStoreContext);
   const commonStore = useContext(CommonStoreContext);
@@ -218,6 +211,7 @@ const ChannelChatBox = ({
                 onReaction={handleReaction}
                 onMessageDelete={handleMessageDelete}
                 currentUser={commonStore.moderator}
+                setChatDropdownMaskVisible={setChatDropdownMaskVisible}
               />
             </ChatMessageBox>
           </ChatMessageBoxWrapper>
@@ -271,6 +265,7 @@ const ChannelChatBox = ({
                   displayMode="thread-full"
                   onReaction={handleReaction}
                   currentUser={commonStore.moderator}
+                  setChatDropdownMaskVisible={setChatDropdownMaskVisible}
                 />
                 <Divider plain orientation="left">
                   {selectedMessage.thread_info?.reply_count ?? 0} replies
@@ -288,6 +283,7 @@ const ChannelChatBox = ({
                     replies={replies}
                     onReaction={handleReaction}
                     currentUser={commonStore.moderator}
+                    setChatDropdownMaskVisible={setChatDropdownMaskVisible}
                   />
                   <ChatInputBox
                     chatBoxBorderColor={chatBoxBorderColor}

--- a/src/components/channel/ChannelChatList.tsx
+++ b/src/components/channel/ChannelChatList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { SetStateAction } from 'react';
 import { MessageLine } from '../message/MessageLine';
 import { MessageType } from '../../types/message';
 import { observer } from 'mobx-react-lite';
@@ -24,6 +24,7 @@ const ChannelChatList = ({
   onReaction,
   onMessageDelete,
   currentUser,
+  setChatDropdownMaskVisible,
 }: {
   loading: boolean;
   messages: MessageType[];
@@ -35,6 +36,7 @@ const ChannelChatList = ({
   ) => void;
   onMessageDelete?: (message: MessageType) => void;
   currentUser: UserListRes | null;
+  setChatDropdownMaskVisible: React.Dispatch<SetStateAction<boolean>>;
 }) => {
   if (loading) {
     return (
@@ -81,6 +83,7 @@ const ChannelChatList = ({
             onReaction={onReaction}
             currentUser={currentUser}
             showDateLine={firstMsgOfTheDay}
+            setChatDropdownMaskVisible={setChatDropdownMaskVisible}
           />
         );
       })}

--- a/src/components/channel/ChannelChatRepliesList.tsx
+++ b/src/components/channel/ChannelChatRepliesList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { SetStateAction } from 'react';
 import { MessageLine } from '../message/MessageLine';
 import { MessageType } from '../../types/message';
 import { UserListRes } from '../../types/user';
@@ -9,6 +9,7 @@ export const ChannelChatRepliesList = ({
   replies,
   onReaction,
   currentUser,
+  setChatDropdownMaskVisible,
 }: {
   replies: MessageType[];
   onReaction: (
@@ -17,13 +18,14 @@ export const ChannelChatRepliesList = ({
     op: ReactionOpType,
   ) => void;
   currentUser: UserListRes | null;
+  setChatDropdownMaskVisible: React.Dispatch<SetStateAction<boolean>>;
 }) => {
   return (
     <div>
       {replies.length === 0 && (
         <Empty description="No replies" image={Empty.PRESENTED_IMAGE_SIMPLE} />
       )}
-      {replies.map((reply, index) => {
+      {replies.map((reply) => {
         return (
           <MessageLine
             key={reply.uuid}
@@ -31,6 +33,7 @@ export const ChannelChatRepliesList = ({
             displayMode="thread-compact"
             onReaction={onReaction}
             currentUser={currentUser}
+            setChatDropdownMaskVisible={setChatDropdownMaskVisible}
           />
         );
       })}

--- a/src/hooks/useOutsideAlerter.tsx
+++ b/src/hooks/useOutsideAlerter.tsx
@@ -5,21 +5,17 @@ import React, { useEffect } from 'react';
  */
 export function useOutsideAlerter(
   ref: React.RefObject<any>,
-  callback: () => void,
-  exception?: any,
+  callback: (event: any) => void,
 ) {
   useEffect(() => {
     /**
      * Alert if clicked on outside of element
      */
-    function handleClickOutside(event: any) {
-      if (ref.current && exception && exception?.contains(event.target)) {
-        return;
-      }
+    const handleClickOutside = (event: any) => {
       if (ref.current && !ref.current.contains(event.target)) {
-        callback();
+        callback(event);
       }
-    }
+    };
 
     // Bind the event listener
     document.addEventListener('mousedown', handleClickOutside);
@@ -28,4 +24,30 @@ export function useOutsideAlerter(
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [ref]);
+}
+
+export function useConditionalOutsideAlerter(
+  ref: React.RefObject<any>,
+  condition: boolean,
+  callback: (event: any) => void,
+) {
+  useEffect(() => {
+    /**
+     * Alert if clicked on outside of element
+     */
+    const handleClickOutside = (event: any) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback(event);
+      }
+    };
+
+    // Bind the event listener
+    if (condition) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, condition]);
 }

--- a/src/pages/channel/ChannelChatPage.tsx
+++ b/src/pages/channel/ChannelChatPage.tsx
@@ -12,10 +12,21 @@ import { CustomUploadFile } from '../../types/attachment';
 import { ChatStoreContext } from '../application/ApplicationRoot';
 import { flowResult } from 'mobx';
 import { useScrollBottom } from '../../hooks/useScrollBottom';
+import styled from 'styled-components';
+
+const ChatDropdownMask = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: 1000;
+`;
 
 const ChannelChatPage = () => {
   const [channelInfoRightSideBarVisible, setChannelInfoRightSideBarVisible] =
     useState(true);
+  const [chatDropdownMaskVisible, setChatDropdownMaskVisible] = useState(false);
 
   const commonStore = useContext(CommonStoreContext);
   const chatStore = useContext(ChatStoreContext);
@@ -133,8 +144,11 @@ const ChannelChatPage = () => {
         display: 'flex',
         flexDirection: 'row',
         background: '#fff',
+        position: 'relative',
       }}
     >
+      {chatDropdownMaskVisible && <ChatDropdownMask />}
+
       <ChannelListSideBar
         application={selectedApplication}
         channels={chatStore.channels}
@@ -167,6 +181,7 @@ const ChannelChatPage = () => {
         onReplyUpload={async (file) => {
           await flowResult(chatStore.handleReplyAttachmentUpload(file));
         }}
+        setChatDropdownMaskVisible={setChatDropdownMaskVisible}
       />
 
       {channelInfoRightSideBarVisible && (

--- a/src/types/reaction.ts
+++ b/src/types/reaction.ts
@@ -1,1 +1,12 @@
 export type ReactionOpType = 'add' | 'delete';
+
+export const ReactionToEmojiMap: Record<string, string> = {
+  like: '👍',
+  love: '❤️',
+  haha: '😂',
+  wow: '😮',
+  sad: '😢',
+  angry: '😡',
+  check: '✅',
+  clap: '👏',
+};


### PR DESCRIPTION
## ✍️ Describe your changes
Fixed chat message ActionBox and Dropdown to behave as expected.

### Expected behaviours
- When user hovers the mouse over a message, ActionBox of the message should appear. If the mouse moves away from the message, ActionBox should disappear except for in some cases noted below.
- When the Dropdown is open, and the user clicks on any area beside the opened Dropdown, the Dropdown and the ActionBox should be closed.
- When a Dropdown is open, ActionBox of any other messages should not be visible.
- When a Dropdown is open, both the ActionBox and the Dropdown should stay open even if user moves the cursor away from the message.
- When a button inside a DropDown is clicked, appropriate logic should be executed and both the Dropdown and the ActionBox should be closed. ActionBox can stay open if the cursor is hovering the message after the click.
- When a Dropdown is open, and another dropdown in the same actionbox is opened, previous dropdown should close. There should be ONLY ONE dropdown open at a time.
- When a Dropdown is open, the chat message of the DropDown should stay highlighted regardless of cursor position.

### Demo

https://github.com/wingflo/dashboard-front/assets/7122981/7c0e3fb8-d29c-4039-aa4b-fae622d6339b


## 🎟 ️Issue ticket number and link

closes #8 

## ✅ Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
